### PR TITLE
fix compilation error: string was broken into two lines

### DIFF
--- a/chapter03/mmap_example.c
+++ b/chapter03/mmap_example.c
@@ -91,8 +91,7 @@ main(int argc, char *argv[])
 	close(fd);
 
 	/* store a string to the Persistent Memory */
-	strcpy(pmaddr, "This is new data written to the 
-			file");
+	strcpy(pmaddr, "This is new data written to the file");
 
 	/*
 	 * Simplest way to flush is to call msync(). 


### PR DESCRIPTION
In chapter03, a string in `mmap_example.c` was broken into two lines, which causes compilation error.